### PR TITLE
Add Blender-QKZN AI assistant addon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make test

--- a/Blender-qkzn/LICENSE
+++ b/Blender-qkzn/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Blender-QKZN Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Blender-qkzn/Makefile
+++ b/Blender-qkzn/Makefile
@@ -1,0 +1,17 @@
+PYTHON ?= python3
+
+.PHONY: lint test zip dev
+
+lint:
+$(PYTHON) -m ruff check Blender-qkzn/addons/blender_qkzn
+$(PYTHON) -m black --check Blender-qkzn/addons/blender_qkzn
+$(PYTHON) -m mypy Blender-qkzn/addons/blender_qkzn
+
+test:
+$(PYTHON) -m pytest -q Blender-qkzn/addons/blender_qkzn/tests
+
+zip:
+$(PYTHON) tools/make_zip.py
+
+dev:
+$(PYTHON) -m pip install -e .[dev]

--- a/Blender-qkzn/README.md
+++ b/Blender-qkzn/README.md
@@ -1,0 +1,93 @@
+# Blender-QKZN
+
+Blender-QKZN 是一款面向 Blender 3.6+ 的中文 AI 助手插件。在 3D 视图的侧边栏中新增 "AI 助手" 面板，可通过中文自然语言命令快速创建模型、应用材质与调整对象位置。插件内置规则解析器，可离线使用；同时也支持自定义 HTTP LLM 接口，扩展更复杂的语义理解。
+
+## 功能特性
+
+- 中文自然语言命令 → Blender 操作计划（Plan）
+- 规则解析与可选外部 LLM 解析（HTTP 接口，可配置 API URL / Key / 超时）
+- 安全执行器：逐步调用 `bpy.ops`，输出日志并捕获异常
+- 内置材质预设（玻璃、金属、木纹、塑料）及常见颜色词识别
+- Blender 面板操作：命令输入、启用 LLM、快速跳转首选项、执行/清空按钮
+- 单元测试（pytest + mock），覆盖规划器与执行器核心逻辑
+- 完整工程化支持：black、ruff、mypy、GitHub Actions CI、打包脚本
+
+## 环境要求
+
+- Blender 3.6 及以上版本
+- Python 3.11（用于开发、单元测试与工程脚本）
+- 依赖：`pydantic`, `requests`, `pytest`, `black`, `ruff`, `mypy`
+
+## 安装与打包
+
+1. 克隆或下载本仓库：
+   ```bash
+   git clone <repo-url>
+   cd Blender-qkzn
+   ```
+2. 打包插件：
+   ```bash
+   python tools/make_zip.py
+   ```
+   执行成功后会在项目根目录生成 `blender_qkzn.zip`。
+3. 打开 Blender，依次点击 `Edit > Preferences > Add-ons > Install...`，选择 `blender_qkzn.zip`，勾选启用插件。
+
+## 使用步骤
+
+1. 在 3D 视图侧边栏（`N` 键）切换到 "AI" 分类，找到 "AI 助手" 面板。
+2. 在命令输入框中输入中文指令，例如：
+   - “添加一个立方体并应用玻璃材质”
+   - “添加一个蓝色球体，移动到 X1 Y-2 Z0.5”
+   - “添加一个木纹材质的立方体，再添加一个金属球体”
+3. 勾选 “使用 LLM” 可启用外部 LLM 接口（需先在首选项里配置 API URL 与 API Key）。
+4. 点击 “执行” 按钮，执行器会逐步完成计划并在状态栏输出执行结果。
+5. 如需重置输入，点击 “清空” 按钮。
+
+## 配置外部 LLM
+
+- 在 `Edit > Preferences > Add-ons` 中找到 Blender-QKZN，点击设置按钮。
+- 填写 HTTP 接口的 `API URL`、`API Key`（如需）以及超时时间。
+- LLM 服务需返回 JSON，包含 `plan` 字段或直接提供步骤数组，每个步骤形如：
+  ```json
+  {
+    "op": "mesh.primitive_cube_add",
+    "args": {}
+  }
+  ```
+- 若未配置或调用失败，插件会自动回退到内置规则解析。
+
+## 本地规则解析机制
+
+- 通过正则匹配识别“立方体”“球体”“移动到 X/Y/Z”“玻璃/金属/木纹/塑料材质”等关键语句。
+- 颜色词（红、绿、蓝、黄、白、黑、紫、青、品红、橙）会转换为材质颜色。
+- 输出的 Plan 由多个步骤组成，依次交由执行器执行。
+
+## 开发与测试
+
+```bash
+# 安装开发依赖
+pip install .[dev]
+
+# 代码风格检查
+make lint
+
+# 运行单元测试
+make test
+
+# 快速打包
+make zip
+```
+
+如需在 Blender 中调试，可将 `Blender-qkzn/addons/blender_qkzn` 目录软链接或复制到 Blender 的 addons 目录，并在脚本编辑器中 `import importlib; import blender_qkzn; importlib.reload(blender_qkzn)`。
+
+## 常见问题
+
+- **Blender 找不到插件？** 请确认安装 zip 后在插件列表勾选启用，并查看 Blender 控制台输出日志。
+- **Windows 权限问题？** 确保对 `%APPDATA%/Blender Foundation/Blender/3.6/scripts/addons` 目录具有写入权限。
+- **macOS 沙盒提示？** 将插件放入 `~/Library/Application Support/Blender/3.6/scripts/addons`，并给予 Blender 读写权限。
+- **Linux 路径？** 使用 `~/.config/blender/3.6/scripts/addons` 目录，或根据发行版具体路径调整。
+- **如何接入本地 LLM？** 只需在首选项中设置本地 HTTP 服务地址（如 `http://127.0.0.1:8000/api`），服务需返回符合规范的 JSON。
+
+## 许可证
+
+本项目采用 [MIT License](LICENSE)。欢迎自由使用、修改与分发。

--- a/Blender-qkzn/addons/blender_qkzn/__init__.py
+++ b/Blender-qkzn/addons/blender_qkzn/__init__.py
@@ -1,0 +1,157 @@
+"""Blender-QKZN 插件入口模块，负责注册面板、操作符以及首选项。"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+try:
+    import bpy
+    from bpy.props import BoolProperty, StringProperty
+    from bpy.types import AddonPreferences
+except ImportError:  # pragma: no cover - 仅在非 Blender 环境触发
+    bpy = None  # type: ignore[assignment]
+
+    def BoolProperty(**_kwargs):  # type: ignore[misc]
+        return None
+
+    def StringProperty(**_kwargs):  # type: ignore[misc]
+        return None
+
+    class AddonPreferences:  # type: ignore[override]
+        bl_idname = ""
+
+        def draw(self, _context):
+            return None
+
+from . import executor, llm_client, materials, planner_client, utils
+
+if bpy is not None:
+    from . import operators, ui_panel
+else:  # pragma: no cover - 测试环境不加载 UI
+    operators = None  # type: ignore
+    ui_panel = None  # type: ignore
+
+if TYPE_CHECKING:
+    from bpy.types import Context
+
+
+bl_info = {
+    "name": "Blender-QKZN AI Assistant",
+    "author": "OpenAI ChatGPT",
+    "version": (0, 1, 0),
+    "blender": (3, 6, 0),
+    "location": "View3D > Sidebar",
+    "description": "在侧边栏提供中文自然语言 AI 助手，支持规则解析与可选 LLM",
+    "warning": "",
+    "category": "3D View",
+}
+
+
+class QKZNAddonPreferences(AddonPreferences):
+    """插件首选项，用于配置外部 LLM 接口与日志级别。"""
+
+    bl_idname = __name__
+
+    api_url: StringProperty(
+        name="LLM API 地址",
+        description="可选的 HTTP LLM 服务地址，留空则仅使用本地规则解析",
+        default="",
+    )
+    api_key: StringProperty(
+        name="LLM API Key",
+        description="可选的密钥或 Token",
+        default="",
+    )
+    timeout: bpy.props.IntProperty(  # type: ignore[attr-defined]
+        name="请求超时 (秒)",
+        default=30,
+        min=5,
+        description="外部 LLM 请求的超时时间",
+    )
+    use_llm_default: bpy.props.BoolProperty(  # type: ignore[attr-defined]
+        name="默认启用 LLM",
+        default=False,
+        description="勾选后默认使用 LLM 解析计划",
+    )
+    log_level: bpy.props.EnumProperty(  # type: ignore[attr-defined]
+        name="日志级别",
+        items=[
+            ("INFO", "信息", "输出常规信息"),
+            ("DEBUG", "调试", "输出详细调试信息"),
+            ("WARNING", "警告", "仅输出警告及错误"),
+            ("ERROR", "错误", "仅输出错误"),
+        ],
+        default="INFO",
+    )
+
+    def draw(self, context: Context) -> None:  # type: ignore[name-defined]
+        layout = self.layout
+        layout.label(text="配置外部 LLM 服务与默认行为")
+        layout.prop(self, "api_url")
+        layout.prop(self, "api_key")
+        layout.prop(self, "timeout")
+        layout.prop(self, "use_llm_default")
+        layout.prop(self, "log_level")
+
+
+CLASSES = ()
+if bpy is not None:
+    CLASSES = (
+        QKZNAddonPreferences,
+        operators.QKZNRunAICommandOperator,
+        operators.QKZNClearLogOperator,
+        ui_panel.QKZNAIAssistantPanel,
+    )
+
+
+def register() -> None:
+    """注册插件中的自定义类型、首选项与属性。"""
+
+    if bpy is None:
+        raise RuntimeError("Blender 环境缺少 bpy，无法注册插件")
+
+    for module in (executor, llm_client, materials, planner_client, ui_panel, operators, utils):
+        if module is not None:
+            importlib.reload(module)
+
+    bpy.utils.register_class(QKZNAddonPreferences)
+    for cls in CLASSES[1:]:
+        bpy.utils.register_class(cls)
+
+    bpy.types.Scene.ai_input = StringProperty(  # type: ignore[attr-defined]
+        name="AI 命令",
+        description="输入中文自然语言命令，例如：添加一个红色立方体",
+        default="",
+    )
+    pref_default = False
+    prefs = utils.get_preferences()
+    if prefs and getattr(prefs, "use_llm_default", None):
+        pref_default = bool(prefs.use_llm_default)
+    bpy.types.Scene.ai_use_llm = BoolProperty(  # type: ignore[attr-defined]
+        name="使用 LLM",
+        description="在执行命令时调用配置的 LLM 服务",
+        default=pref_default,
+    )
+
+    utils.get_logger(__name__).info("Blender-QKZN 插件已注册")
+
+
+def unregister() -> None:
+    """卸载插件时清理注册的类型与属性。"""
+
+    if bpy is None:
+        return
+
+    del bpy.types.Scene.ai_input
+    del bpy.types.Scene.ai_use_llm
+
+    for cls in reversed(CLASSES[1:]):
+        bpy.utils.unregister_class(cls)
+    bpy.utils.unregister_class(QKZNAddonPreferences)
+
+    utils.get_logger(__name__).info("Blender-QKZN 插件已卸载")
+
+
+if __name__ == "__main__":
+    register()

--- a/Blender-qkzn/addons/blender_qkzn/executor.py
+++ b/Blender-qkzn/addons/blender_qkzn/executor.py
@@ -1,0 +1,81 @@
+"""执行器模块：负责按顺序执行规划好的步骤。"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Sequence
+
+from . import materials, utils
+from .schemas import Plan, PlanStep, validate_plan
+
+try:
+    import bpy
+except ImportError:  # pragma: no cover - 测试环境无 bpy
+    bpy = None  # type: ignore[assignment]
+
+
+class ExecutionError(RuntimeError):
+    """执行过程中的统一异常类型。"""
+
+
+def _resolve_bpy_operator(path: str) -> Callable[..., Any]:
+    """根据路径字符串获取 bpy 操作函数。"""
+
+    if bpy is None:
+        raise ExecutionError("当前环境缺少 bpy，无法执行操作")
+    parts = path.split(".")
+    target: Any = bpy.ops
+    for part in parts:
+        target = getattr(target, part)
+    return target
+
+
+def _execute_single_step(step: PlanStep) -> None:
+    """执行单个步骤，支持内建操作与自定义伪操作。"""
+
+    logger = utils.get_logger(__name__)
+    logger.debug("执行步骤: %s", step)
+
+    if step.op == "material.assign":
+        if bpy is None:
+            raise ExecutionError("缺少 bpy，无法应用材质")
+        active_obj = bpy.context.active_object
+        materials.apply_material(active_obj, step.args.get("spec"))
+        return
+
+    if step.op == "object.move":
+        if bpy is None:
+            raise ExecutionError("缺少 bpy，无法移动对象")
+        active_obj = bpy.context.active_object
+        if active_obj is None:
+            raise ExecutionError("当前没有激活对象，无法移动")
+        location = step.args.get("location")
+        if not isinstance(location, Sequence):
+            raise ExecutionError("移动指令缺少 location 参数")
+        active_obj.location = location
+        return
+
+    operator = _resolve_bpy_operator(step.op)
+    operator(**step.args)
+
+
+def execute_plan(plan_input: Any) -> None:
+    """执行计划并记录日志统计信息。"""
+
+    plan: Plan = validate_plan(plan_input)
+    logger = utils.get_logger(__name__)
+    success = 0
+    failed = 0
+
+    for index, step in enumerate(plan.steps, start=1):
+        try:
+            _execute_single_step(step)
+            success += 1
+            logger.info("步骤 %d 成功: %s", index, step.op)
+        except Exception as exc:  # pragma: no cover - 错误路径
+            failed += 1
+            logger.error("步骤 %d 失败 (%s): %s", index, step.op, exc)
+
+    logger.info("计划执行完毕，总步骤 %d，成功 %d，失败 %d", len(plan.steps), success, failed)
+
+    if failed:
+        raise ExecutionError(f"计划执行存在失败步骤：成功 {success} / 失败 {failed}")

--- a/Blender-qkzn/addons/blender_qkzn/llm_client.py
+++ b/Blender-qkzn/addons/blender_qkzn/llm_client.py
@@ -1,0 +1,46 @@
+"""可选的 LLM HTTP 客户端，用于将文本转换成计划。"""
+
+from __future__ import annotations
+
+from typing import List
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - 测试环境可无 requests
+    requests = None  # type: ignore[assignment]
+
+from . import utils
+from .schemas import LLMConfig, PlanStep, validate_plan
+
+
+def generate_plan(text: str, cfg: LLMConfig) -> List[PlanStep]:
+    """调用外部 LLM 服务，将文本解析为计划步骤列表。"""
+
+    if not cfg.api_url:
+        raise ValueError("未配置 LLM API 地址，无法调用外部模型")
+
+    if requests is None:
+        raise RuntimeError("当前环境未安装 requests，无法调用外部 LLM 接口")
+
+    headers = {"Content-Type": "application/json"}
+    if cfg.api_key:
+        headers["Authorization"] = f"Bearer {cfg.api_key}"
+
+    payload = {"prompt": text}
+    logger = utils.get_logger(__name__)
+    logger.info("请求外部 LLM: %s", cfg.api_url)
+
+    response = requests.post(cfg.api_url, json=payload, timeout=cfg.timeout, headers=headers)
+    response.raise_for_status()
+
+    data = response.json()
+    plan_raw = data.get("plan", data)
+    plan = validate_plan(plan_raw)
+    logger.info("LLM 返回 %d 个步骤", len(plan.steps))
+    return plan.steps
+
+
+# 使用说明：
+#  - 如果需要接入自托管或本地 LLM，请在插件首选项中填写 API 地址与密钥。
+#  - API 返回的 JSON 应包含 "plan" 字段或直接是步骤数组。
+#  - 每个步骤需要提供 op 与 args 字段，例如 {"op": "mesh.primitive_cube_add", "args": {}}。

--- a/Blender-qkzn/addons/blender_qkzn/materials.py
+++ b/Blender-qkzn/addons/blender_qkzn/materials.py
@@ -1,0 +1,117 @@
+"""材质工具，负责读取预设并在 Blender 中创建材质。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Union
+
+from . import utils
+
+try:
+    import bpy
+except ImportError:  # pragma: no cover - 测试环境无 bpy
+    bpy = None  # type: ignore[assignment]
+
+_PRESETS_CACHE: Optional[Dict[str, Dict[str, Any]]] = None
+_PRESET_PATH = Path(__file__).parent / "presets" / "materials.json"
+
+
+def _load_presets() -> Dict[str, Dict[str, Any]]:
+    """加载 JSON 材质预设，采用懒加载缓存。"""
+
+    global _PRESETS_CACHE
+    if _PRESETS_CACHE is None:
+        with _PRESET_PATH.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        _PRESETS_CACHE = {key: value for key, value in data.items()}
+    return _PRESETS_CACHE
+
+
+def _match_preset(name: str) -> Optional[Dict[str, Any]]:
+    """根据中文名称或别名匹配预设。"""
+
+    presets = _load_presets()
+    lowered = name.lower()
+    if lowered in presets:
+        return presets[lowered]
+    for preset in presets.values():
+        for alias in preset.get("aliases", []):
+            if alias.lower() == lowered:
+                return preset
+    return None
+
+
+def ensure_material(name: str, principled: Optional[Dict[str, Any]] = None):
+    """保证材质存在，并根据配置更新节点参数。"""
+
+    if bpy is None:
+        raise RuntimeError("当前环境缺少 bpy，无法创建材质")
+    material = bpy.data.materials.get(name)
+    if material is None:
+        material = bpy.data.materials.new(name=name)
+        material.use_nodes = True
+    if not material.use_nodes:
+        material.use_nodes = True
+    node_tree = material.node_tree
+    if not node_tree:
+        return material
+    bsdf = node_tree.nodes.get("Principled BSDF")
+    if bsdf is None:
+        bsdf = node_tree.nodes.new("ShaderNodeBsdfPrincipled")
+    if principled:
+        for key, value in principled.items():
+            input_socket = bsdf.inputs.get(key)
+            if input_socket is None:
+                continue
+            if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+                sequence = list(value)
+                if len(sequence) == 3:
+                    sequence.append(1.0)
+                input_socket.default_value = sequence  # type: ignore[assignment]
+            else:
+                input_socket.default_value = value  # type: ignore[assignment]
+    return material
+
+
+def apply_material(obj: Any, spec: Union[str, Dict[str, Any]]) -> None:
+    """为对象应用材质，可通过预设或颜色词指定。"""
+
+    if bpy is None:
+        raise RuntimeError("当前环境缺少 bpy，无法应用材质")
+    if obj is None:
+        raise ValueError("未找到可应用材质的对象")
+
+    principled: Optional[Dict[str, Any]] = None
+    material_name = ""
+
+    if isinstance(spec, str):
+        color = utils.color_from_text(spec)
+        if color:
+            material_name = f"QKZN_Color_{spec}"
+            principled = {"Base Color": (*color, 1.0)}
+        else:
+            preset = _match_preset(spec)
+            if preset:
+                material_name = preset["name"]
+                principled = preset.get("principled")
+            else:
+                material_name = spec
+    elif isinstance(spec, dict):
+        material_name = spec.get("name", "QKZN_Custom")
+        principled = spec.get("principled")
+    else:
+        raise TypeError("材质描述必须为字符串或字典")
+
+    material = ensure_material(material_name or "QKZN_Default", principled)
+
+    if obj.data is None:
+        raise ValueError("当前对象没有几何数据，无法绑定材质")
+
+    if material.name not in [slot.name for slot in obj.material_slots]:
+        if obj.data.materials:
+            obj.data.materials[0] = material
+        else:
+            obj.data.materials.append(material)
+
+    utils.get_logger(__name__).info("已为对象 %s 应用材质 %s", obj.name, material.name)

--- a/Blender-qkzn/addons/blender_qkzn/operators.py
+++ b/Blender-qkzn/addons/blender_qkzn/operators.py
@@ -1,0 +1,72 @@
+"""自定义 Blender 操作符，封装执行逻辑。"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import bpy
+from bpy.types import Context, Operator
+
+from . import executor, planner_client, utils
+from .schemas import LLMConfig
+
+
+class QKZNRunAICommandOperator(Operator):
+    """执行自然语言命令的操作符。"""
+
+    bl_idname = "qkzn.run_ai_command"
+    bl_label = "执行 AI 命令"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context: Context) -> set[str]:
+        utils.ensure_logger_level_from_prefs()
+        scene = context.scene
+        command = getattr(scene, "ai_input", "")
+        use_llm = bool(getattr(scene, "ai_use_llm", False))
+
+        logger = utils.get_logger(__name__)
+        logger.info("收到命令：%s", command)
+
+        prefs = utils.get_preferences()
+        llm_config: Optional[LLMConfig] = None
+        if prefs:
+            llm_config = LLMConfig(
+                api_url=getattr(prefs, "api_url", None) or None,
+                api_key=getattr(prefs, "api_key", None) or None,
+                timeout=int(getattr(prefs, "timeout", 30)),
+            )
+            if llm_config.api_url and not use_llm and getattr(prefs, "use_llm_default", False):
+                use_llm = True
+
+        try:
+            plan = planner_client.parse_command(command, use_llm=use_llm, llm_config=llm_config)
+            executor.execute_plan(plan)
+        except Exception as exc:  # pragma: no cover - Blender 内部异常难测
+            self.report({"ERROR"}, f"执行失败: {exc}")
+            logger.error("执行失败：%s", exc)
+            return {"CANCELLED"}
+
+        self.report({"INFO"}, "计划执行完成")
+        return {"FINISHED"}
+
+
+class QKZNClearLogOperator(Operator):
+    """简单重置输入的操作符。"""
+
+    bl_idname = "qkzn.clear_log"
+    bl_label = "清空命令"
+
+    def execute(self, context: Context) -> set[str]:
+        context.scene.ai_input = ""
+        self.report({"INFO"}, "已清空输入")
+        return {"FINISHED"}
+
+
+def register() -> None:
+    bpy.utils.register_class(QKZNRunAICommandOperator)
+    bpy.utils.register_class(QKZNClearLogOperator)
+
+
+def unregister() -> None:
+    bpy.utils.unregister_class(QKZNClearLogOperator)
+    bpy.utils.unregister_class(QKZNRunAICommandOperator)

--- a/Blender-qkzn/addons/blender_qkzn/planner_client.py
+++ b/Blender-qkzn/addons/blender_qkzn/planner_client.py
@@ -1,0 +1,94 @@
+"""规划器模块：将中文自然语言解析为 Blender 可执行计划。"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional
+
+from . import llm_client, utils
+from .schemas import LLMConfig, Plan, PlanStep, validate_plan
+
+
+_COLOR_PATTERN = "|".join(utils.available_color_words())
+_MATERIAL_PATTERN = "玻璃|金属|木纹|塑料"
+
+_ADD_CUBE_RE = re.compile(
+    rf"添加(?:一个)?(?:(?P<material>{_MATERIAL_PATTERN})材质的)?(?:(?P<color>{_COLOR_PATTERN})的?)?(立方体|方块|cube)",
+    re.IGNORECASE,
+)
+_ADD_SPHERE_RE = re.compile(
+    rf"添加(?:一个)?(?:(?P<material>{_MATERIAL_PATTERN})(?:材质)?的?)?(?:(?P<color>{_COLOR_PATTERN})的?)?(球体|圆球)",
+    re.IGNORECASE,
+)
+_APPLY_MATERIAL_RE = re.compile(
+    rf"应用(?:.*?)(?P<material>{_MATERIAL_PATTERN})(?:材质)?",
+    re.IGNORECASE,
+)
+_MOVE_RE = re.compile(
+    r"移动到\s*X(?P<x>-?\d+(?:\.\d+)?)\s*Y(?P<y>-?\d+(?:\.\d+)?)\s*Z(?P<z>-?\d+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
+
+
+def parse_command(text: str, use_llm: bool = False, llm_config: Optional[LLMConfig] = None) -> Plan:
+    """将中文命令解析为 Plan，如果启用 LLM 则优先调用外部接口。"""
+
+    cleaned = text.strip()
+    if not cleaned:
+        raise ValueError("请输入有效的命令文本")
+
+    logger = utils.get_logger(__name__)
+
+    if use_llm:
+        try:
+            config = llm_config or LLMConfig(api_url=None, api_key=None, timeout=30)
+            plan_obj = llm_client.generate_plan(cleaned, config)
+            logger.info("LLM 解析成功，返回计划")
+            return validate_plan(plan_obj)
+        except Exception as exc:  # pragma: no cover - 网络相关异常在测试中难模拟
+            logger.warning("LLM 解析失败，回退到规则解析：%s", exc)
+
+    steps: List[PlanStep] = []
+
+    for match in _ADD_CUBE_RE.finditer(cleaned):
+        color = match.group("color")
+        material = match.group("material")
+        steps.append(PlanStep(op="mesh.primitive_cube_add", args={}))
+        if material:
+            steps.append(PlanStep(op="material.assign", args={"spec": material}))
+        if color and not material:
+            steps.append(PlanStep(op="material.assign", args={"spec": color}))
+
+    for match in _ADD_SPHERE_RE.finditer(cleaned):
+        color = match.group("color")
+        material = match.group("material")
+        steps.append(PlanStep(op="mesh.primitive_uv_sphere_add", args={}))
+        if material:
+            steps.append(PlanStep(op="material.assign", args={"spec": material}))
+        if color and not material:
+            steps.append(PlanStep(op="material.assign", args={"spec": color}))
+
+    for match in _APPLY_MATERIAL_RE.finditer(cleaned):
+        material = match.group("material")
+        steps.append(PlanStep(op="material.assign", args={"spec": material}))
+
+    move_match = _MOVE_RE.search(cleaned)
+    if move_match:
+        steps.append(
+            PlanStep(
+                op="object.move",
+                args={
+                    "location": (
+                        float(move_match.group("x")),
+                        float(move_match.group("y")),
+                        float(move_match.group("z")),
+                    )
+                },
+            )
+        )
+
+    if not steps:
+        raise ValueError("未能解析命令，请尝试更简单的描述或启用 LLM")
+
+    logger.info("规则解析生成 %d 步计划", len(steps))
+    return Plan(steps=steps)

--- a/Blender-qkzn/addons/blender_qkzn/presets/materials.json
+++ b/Blender-qkzn/addons/blender_qkzn/presets/materials.json
@@ -1,0 +1,36 @@
+{
+  "glass": {
+    "name": "QKZN_Glass",
+    "aliases": ["玻璃", "玻璃材质"],
+    "principled": {
+      "Base Color": [0.8, 0.9, 1.0, 1.0],
+      "Transmission": 1.0,
+      "Roughness": 0.05
+    }
+  },
+  "metal": {
+    "name": "QKZN_Metal",
+    "aliases": ["金属", "金属材质"],
+    "principled": {
+      "Base Color": [0.7, 0.7, 0.7, 1.0],
+      "Metallic": 1.0,
+      "Roughness": 0.2
+    }
+  },
+  "wood": {
+    "name": "QKZN_Wood",
+    "aliases": ["木纹", "木纹材质", "木材"],
+    "principled": {
+      "Base Color": [0.5, 0.3, 0.1, 1.0],
+      "Roughness": 0.6
+    }
+  },
+  "plastic": {
+    "name": "QKZN_Plastic",
+    "aliases": ["塑料", "塑料材质"],
+    "principled": {
+      "Base Color": [0.9, 0.9, 0.9, 1.0],
+      "Roughness": 0.4
+    }
+  }
+}

--- a/Blender-qkzn/addons/blender_qkzn/schemas.py
+++ b/Blender-qkzn/addons/blender_qkzn/schemas.py
@@ -1,0 +1,49 @@
+"""数据模型定义，使用 Pydantic 提供强类型校验。"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, ValidationError, root_validator
+
+
+class PlanStep(BaseModel):
+    """单个计划步骤，描述一个 Blender 操作。"""
+
+    op: str
+    args: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Plan(BaseModel):
+    """完整计划，由多个步骤组成。"""
+
+    steps: List[PlanStep]
+
+    @root_validator
+    def check_steps_not_empty(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if not values.get("steps"):
+            raise ValueError("计划步骤不能为空")
+        return values
+
+
+class LLMConfig(BaseModel):
+    """LLM 请求配置。"""
+
+    api_url: Optional[str]
+    api_key: Optional[str]
+    timeout: int = 30
+
+
+def validate_plan(raw: Any) -> Plan:
+    """验证任意对象能否转为 Plan，错误时抛出中文提示。"""
+
+    try:
+        if isinstance(raw, Plan):
+            return raw
+        if isinstance(raw, dict) and "steps" in raw:
+            return Plan.parse_obj(raw)
+        if isinstance(raw, list):
+            return Plan(steps=[PlanStep.parse_obj(item) for item in raw])
+        raise TypeError("计划数据结构不正确，需为列表或包含 steps 的字典")
+    except (ValidationError, TypeError, ValueError) as exc:  # pragma: no cover - 错误路径
+        raise ValueError(f"计划校验失败：{exc}") from exc

--- a/Blender-qkzn/addons/blender_qkzn/tests/test_executor_plan.py
+++ b/Blender-qkzn/addons/blender_qkzn/tests/test_executor_plan.py
@@ -1,0 +1,62 @@
+"""执行器执行顺序与异常处理测试。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from blender_qkzn import executor
+from blender_qkzn.schemas import Plan, PlanStep
+
+
+def _prepare_fake_bpy() -> None:
+    cube_add = MagicMock(name="cube_add")
+    fake_mesh = SimpleNamespace(primitive_cube_add=cube_add)
+    fake_ops = SimpleNamespace(mesh=fake_mesh)
+
+    active_object = SimpleNamespace(
+        name="TestObject",
+        location=(0.0, 0.0, 0.0),
+        material_slots=[],
+        data=SimpleNamespace(materials=[]),
+    )
+    fake_context = SimpleNamespace(active_object=active_object)
+
+    executor.bpy = SimpleNamespace(ops=fake_ops, context=fake_context)  # type: ignore[attr-defined]
+    executor.materials.apply_material = MagicMock(name="apply_material")  # type: ignore[assignment]
+
+    return cube_add, active_object
+
+
+def test_execute_plan_success() -> None:
+    cube_add, active_object = _prepare_fake_bpy()
+
+    plan = Plan(
+        steps=[
+            PlanStep(op="mesh.primitive_cube_add", args={}),
+            PlanStep(op="material.assign", args={"spec": "玻璃"}),
+            PlanStep(op="object.move", args={"location": (1.0, 2.0, 3.0)}),
+        ]
+    )
+
+    executor.execute_plan(plan)
+
+    cube_add.assert_called_once()
+    executor.materials.apply_material.assert_called_once_with(active_object, "玻璃")  # type: ignore[attr-defined]
+    assert executor.bpy.context.active_object.location == (1.0, 2.0, 3.0)  # type: ignore[attr-defined]
+
+
+def test_execute_plan_failure_raises() -> None:
+    cube_add, _ = _prepare_fake_bpy()
+    cube_add.side_effect = RuntimeError("boom")
+
+    plan = Plan(steps=[PlanStep(op="mesh.primitive_cube_add", args={})])
+
+    with pytest.raises(executor.ExecutionError):
+        executor.execute_plan(plan)

--- a/Blender-qkzn/addons/blender_qkzn/tests/test_rules_planner.py
+++ b/Blender-qkzn/addons/blender_qkzn/tests/test_rules_planner.py
@@ -1,0 +1,43 @@
+"""规划器规则解析的单元测试。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from blender_qkzn import planner_client
+
+
+def test_parse_cube_with_material() -> None:
+    plan = planner_client.parse_command("添加一个立方体并应用玻璃材质")
+    ops = [step.op for step in plan.steps]
+    assert ops == ["mesh.primitive_cube_add", "material.assign"]
+    assert plan.steps[1].args["spec"] == "玻璃"
+
+
+def test_parse_sphere_move() -> None:
+    plan = planner_client.parse_command("添加一个蓝色球体，移动到 X1 Y-2 Z0.5")
+    ops = [step.op for step in plan.steps]
+    assert ops == [
+        "mesh.primitive_uv_sphere_add",
+        "material.assign",
+        "object.move",
+    ]
+    assert plan.steps[1].args["spec"] == "蓝色"
+    assert plan.steps[2].args["location"] == (1.0, -2.0, 0.5)
+
+
+def test_parse_multi_shape_materials() -> None:
+    text = "添加一个木纹材质的立方体，再添加一个金属球体"
+    plan = planner_client.parse_command(text)
+    ops = [step.op for step in plan.steps]
+    assert ops == [
+        "mesh.primitive_cube_add",
+        "material.assign",
+        "mesh.primitive_uv_sphere_add",
+        "material.assign",
+    ]
+    assert plan.steps[1].args["spec"] == "木纹"
+    assert plan.steps[3].args["spec"] == "金属"

--- a/Blender-qkzn/addons/blender_qkzn/ui_panel.py
+++ b/Blender-qkzn/addons/blender_qkzn/ui_panel.py
@@ -1,0 +1,31 @@
+"""UI 面板定义：在 3D 视图的侧边栏提供交互。"""
+
+from __future__ import annotations
+
+import bpy
+from bpy.types import Panel
+
+
+class QKZNAIAssistantPanel(Panel):
+    """AI 助手面板，提供命令输入与操作按钮。"""
+
+    bl_label = "AI 助手"
+    bl_idname = "QKZN_PT_ai_assistant"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "AI"
+
+    def draw(self, context: bpy.types.Context) -> None:
+        layout = self.layout
+        scene = context.scene
+
+        layout.prop(scene, "ai_input", text="命令")
+        layout.prop(scene, "ai_use_llm", text="使用 LLM")
+
+        row = layout.row(align=True)
+        op = row.operator("wm.addon_userpref_show", text="设置", icon="PREFERENCES")
+        op.module = __package__
+
+        row = layout.row(align=True)
+        row.operator("qkzn.run_ai_command", text="执行", icon="PLAY")
+        row.operator("qkzn.clear_log", text="清空", icon="TRASH")

--- a/Blender-qkzn/addons/blender_qkzn/utils.py
+++ b/Blender-qkzn/addons/blender_qkzn/utils.py
@@ -1,0 +1,74 @@
+"""通用工具模块，封装日志、配置访问与颜色映射逻辑。"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Tuple, Optional, Iterable
+
+try:
+    import bpy
+except ImportError:  # pragma: no cover - 测试环境下可能没有 bpy
+    bpy = None  # type: ignore[assignment]
+
+
+_COLOR_MAP: Dict[str, Tuple[float, float, float]] = {
+    "红色": (1.0, 0.0, 0.0),
+    "绿色": (0.0, 1.0, 0.0),
+    "蓝色": (0.0, 0.0, 1.0),
+    "黄色": (1.0, 1.0, 0.0),
+    "白色": (1.0, 1.0, 1.0),
+    "黑色": (0.0, 0.0, 0.0),
+    "紫色": (0.5, 0.0, 0.5),
+    "青色": (0.0, 1.0, 1.0),
+    "品红": (1.0, 0.0, 1.0),
+    "橙色": (1.0, 0.5, 0.0),
+}
+
+
+def get_logger(name: str) -> logging.Logger:
+    """获取带有中文格式提示的 logger。"""
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("[%(levelname)s][%(name)s] %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger
+
+
+def set_log_level(level: str) -> None:
+    """根据首选项调整全局日志级别。"""
+
+    logging.getLogger().setLevel(level.upper())
+
+
+def get_preferences() -> Optional[object]:
+    """安全获取插件首选项，测试环境下返回 None。"""
+
+    if bpy is None:
+        return None
+    addon_name = __name__.split(".")[0]
+    prefs = bpy.context.preferences.addons.get(addon_name) if bpy else None
+    return getattr(prefs, "preferences", None) if prefs else None
+
+
+def color_from_text(text: str) -> Optional[Tuple[float, float, float]]:
+    """根据中文颜色词返回 RGB 值。"""
+
+    return _COLOR_MAP.get(text)
+
+
+def available_color_words() -> Iterable[str]:
+    """返回可识别的颜色词集合。"""
+
+    return _COLOR_MAP.keys()
+
+
+def ensure_logger_level_from_prefs() -> None:
+    """读取首选项并设置日志级别。"""
+
+    prefs = get_preferences()
+    if prefs and getattr(prefs, "log_level", None):
+        set_log_level(prefs.log_level)

--- a/Blender-qkzn/addons/pydantic/__init__.py
+++ b/Blender-qkzn/addons/pydantic/__init__.py
@@ -1,0 +1,94 @@
+"""简化版 pydantic 兼容层。
+
+在离线或受限环境中无法安装官方 pydantic 时，本模块提供基础兼容能力，
+仅覆盖本项目所需的 `BaseModel`、`Field`、`ValidationError` 与 `root_validator`。
+真实部署建议安装官方 pydantic，以获得完整特性与类型校验能力。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+
+class ValidationError(Exception):
+    """与 pydantic 的 ValidationError 对齐的异常类型。"""
+
+
+class _FieldInfo:
+    def __init__(self, default: Any = ... , default_factory: Optional[Callable[[], Any]] = None):
+        self.default = default
+        self.default_factory = default_factory
+
+
+def Field(*, default: Any = ..., default_factory: Optional[Callable[[], Any]] = None) -> _FieldInfo:
+    """提供与 pydantic.Field 相同的接口。"""
+
+    return _FieldInfo(default=default, default_factory=default_factory)
+
+
+def root_validator(func: Optional[Callable[[Any, Dict[str, Any]], Dict[str, Any]]] = None, **_kwargs):
+    """注册根验证器的装饰器。"""
+
+    def decorator(method: Callable[[Any, Dict[str, Any]], Dict[str, Any]]) -> Callable[[Any, Dict[str, Any]], Dict[str, Any]]:
+        setattr(method, "__is_root_validator__", True)
+        return method
+
+    if func is not None:
+        return decorator(func)
+    return decorator
+
+
+class BaseModelMeta(type):
+    """负责收集字段信息与根验证器的元类。"""
+
+    def __new__(mcls, name: str, bases: tuple[type, ...], namespace: Dict[str, Any]):
+        cls = super().__new__(mcls, name, bases, dict(namespace))
+        annotations: Dict[str, Any] = namespace.get("__annotations__", {})
+        fields: Dict[str, _FieldInfo] = {}
+        for field_name in annotations:
+            value = namespace.get(field_name, ...)
+            if isinstance(value, _FieldInfo):
+                fields[field_name] = value
+            else:
+                fields[field_name] = _FieldInfo(default=value)
+        setattr(cls, "__fields__", fields)
+        validators = []
+        for attr in namespace.values():
+            if getattr(attr, "__is_root_validator__", False):
+                validators.append(attr)
+        setattr(cls, "__root_validators__", validators)
+        return cls
+
+
+class BaseModel(metaclass=BaseModelMeta):
+    """最小化的 BaseModel 实现，支持 parse_obj 与 root_validator。"""
+
+    __fields__: Dict[str, _FieldInfo]
+    __root_validators__: list[Callable[[Any, Dict[str, Any]], Dict[str, Any]]]
+
+    def __init__(self, **data: Any) -> None:
+        values: Dict[str, Any] = {}
+        for name, info in self.__fields__.items():
+            if name in data:
+                values[name] = data[name]
+            elif info.default is not ...:
+                values[name] = info.default
+            elif info.default_factory is not None:
+                values[name] = info.default_factory()
+            else:
+                raise ValidationError(f"字段 {name} 缺失")
+        for validator in self.__root_validators__:
+            values = validator(self.__class__, values)
+        for key, value in values.items():
+            setattr(self, key, value)
+
+    @classmethod
+    def parse_obj(cls, obj: Any) -> "BaseModel":
+        if isinstance(obj, cls):
+            return obj
+        if isinstance(obj, dict):
+            return cls(**obj)
+        raise ValidationError(f"无法解析对象 {obj!r}")
+
+    def dict(self) -> Dict[str, Any]:
+        return dict(self.__dict__)

--- a/Blender-qkzn/pyproject.toml
+++ b/Blender-qkzn/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "blender-qkzn"
+version = "0.1.0"
+description = "Blender AI assistant with Chinese rule-based planner"
+requires-python = ">=3.11"
+dependencies = [
+  "pydantic>=1.10,<2",
+  "requests>=2.31",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+  "black>=23.9",
+  "ruff>=0.1.5",
+  "mypy>=1.7",
+]
+
+[tool.black]
+target-version = ["py311"]
+line-length = 100
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "C90"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+ignore_missing_imports = true

--- a/Blender-qkzn/tools/make_zip.py
+++ b/Blender-qkzn/tools/make_zip.py
@@ -1,0 +1,27 @@
+"""打包脚本：将插件目录压缩成 zip 以供 Blender 安装。"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ADDON_DIR = PROJECT_ROOT / "addons" / "blender_qkzn"
+OUTPUT = PROJECT_ROOT / "blender_qkzn.zip"
+
+
+def main() -> None:
+    if not ADDON_DIR.exists():
+        raise SystemExit(f"未找到插件目录: {ADDON_DIR}")
+
+    print(f"正在打包 {ADDON_DIR} -> {OUTPUT}")
+    with zipfile.ZipFile(OUTPUT, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in ADDON_DIR.rglob("*"):
+            if path.is_file():
+                arcname = path.relative_to(PROJECT_ROOT)
+                zf.write(path, arcname.as_posix())
+    print("打包完成")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Blender sidebar AI assistant with rule-based planner and optional LLM integration
- implement executor, materials presets, and configuration-driven materials support
- provide packaging, CI workflow, and unit tests for planner and executor

## Testing
- `python -m pytest -q Blender-qkzn/addons/blender_qkzn/tests`


------
https://chatgpt.com/codex/tasks/task_e_68e4b1bcbd608330965a7fe0367569db